### PR TITLE
add --numexecutions option

### DIFF
--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -117,6 +117,11 @@ var (
 		Usage:    "The transaction receiver (execution context)",
 		Category: flags.VMCategory,
 	}
+	NumExecutionsFlag = &cli.IntFlag{
+		Name:     "numexecutions",
+		Usage:    "Number of times to execute the code",
+		Category: flags.VMCategory,
+	}
 	DisableMemoryFlag = &cli.BoolFlag{
 		Name:     "nomemory",
 		Value:    true,
@@ -246,6 +251,7 @@ var traceFlags = []cli.Flag{
 	DumpFlag,
 	MachineFlag,
 	StatDumpFlag,
+	NumExecutionsFlag,
 	DisableMemoryFlag,
 	DisableStackFlag,
 	DisableStorageFlag,

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -58,6 +58,7 @@ func stateTestCmd(ctx *cli.Context) error {
 		EnableReturnData: !ctx.Bool(DisableReturnDataFlag.Name),
 	}
 	var cfg vm.Config
+	cfg.NumExecutions = ctx.Int(NumExecutionsFlag.Name)
 	switch {
 	case ctx.Bool(MachineFlag.Name):
 		cfg.Tracer = logger.NewJSONLogger(config, os.Stderr)

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -33,6 +33,7 @@ type Config struct {
 	NoBaseFee               bool  // Forces the EIP-1559 baseFee to 0 (needed for 0 price calls)
 	EnablePreimageRecording bool  // Enables recording of SHA3/keccak preimages
 	ExtraEips               []int // Additional EIPS that are to be enabled
+	NumExecutions           int   // Number of executions to run
 
 	StatelessSelfValidation bool // Generate execution witnesses and self-check against them (testing purpose)
 }


### PR DESCRIPTION
Add `--numexecutions` option to `evm statetest`. Example usage: 

```
❯ go install ./cmd/evm

❯ evm --numexecutions 100000   statetest   /tmp/./coinbaseWarmAccountCallGas-0-0-0/coinbaseWarmAccountCallGas.json
```